### PR TITLE
add: phone number authorization, docs, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Неофициальная асинхронная библиотека **moy_nalog** предоставляет API для автоматизации отчётности самозанятых на [lknpd.nalog.ru](https://npd.nalog.ru/web-app/).
 
 
-Пример использования:
+Авторизация по логину и паролю:
 
 ```python
 import asyncio
@@ -14,6 +14,29 @@ nalog = MoyNalog("1234567890", "MyStrongPassword")
 
 
 async def main():
+    await nalog.add_income(
+        "Предоставление информационных услуг #970/2495", amount=1000, quantity=1
+    )
+
+
+asyncio.run(main())
+```
+
+Авторизация по номеру телефона (SMS):
+
+```python
+import asyncio
+
+from moy_nalog import MoyNalog
+
+nalog = MoyNalog(phone="+79991234567")
+
+
+async def main():
+    challenge = await nalog.request_sms_code()
+    code = input("Введите код из SMS: ")
+    await nalog.verify_sms_code(code, challenge.challenge_token)
+
     await nalog.add_income(
         "Предоставление информационных услуг #970/2495", amount=1000, quantity=1
     )

--- a/docs/source/api/client.rst
+++ b/docs/source/api/client.rst
@@ -6,3 +6,53 @@ MoyNalog
 Кроме того, методы не могут быть использованы без экземпляра с данными для авторизации.
 
 
+Авторизация по логину и паролю
+==============================
+
+Классический способ авторизации через ИНН (или телефон) и пароль от ЛК ФНС:
+
+.. code-block:: python
+
+    from moy_nalog import MoyNalog
+
+    async with MoyNalog(login="1234567890", password="MyPassword") as nalog:
+        user = await nalog.get_user_info()
+
+Авторизация происходит автоматически при первом вызове любого метода API.
+
+
+Авторизация по SMS
+==================
+
+Авторизация через код из SMS-сообщения. Не требует пароля, только номер телефона:
+
+.. code-block:: python
+
+    from moy_nalog import MoyNalog
+
+    async with MoyNalog(phone="79171234567") as nalog:
+        # Шаг 1: запросить SMS-код на телефон
+        challenge = await nalog.request_sms_code()
+        # challenge.challenge_token — токен для верификации
+        # challenge.expire_in — время жизни кода (120 сек)
+
+        # Шаг 2: пользователь вводит код из SMS
+        code = input("Введите код из SMS: ")
+
+        # Шаг 3: верифицировать код и получить токены
+        auth = await nalog.verify_sms_code(
+            code=code,
+            challenge_token=challenge.challenge_token,
+        )
+        # auth.inn — ИНН пользователя
+        # auth.token.value — access token
+        # auth.token.refresh_value — refresh token
+
+        # Шаг 4: теперь можно использовать любые методы
+        user = await nalog.get_user_info()
+
+.. warning::
+
+    При SMS-авторизации перед вызовом методов API (``add_income``, ``get_user_info`` и др.)
+    необходимо сначала пройти верификацию через ``verify_sms_code()``.
+    Иначе будет вызвано исключение ``AuthorizationError``.

--- a/docs/source/api/methods/index.rst
+++ b/docs/source/api/methods/index.rst
@@ -4,6 +4,15 @@
 
 Доступный список методов
 
+Авторизация по SMS
+=====================
+
+.. toctree::
+    :maxdepth: 1
+
+    request_sms_code
+    verify_sms_code
+
 Чеки
 ========
 

--- a/docs/source/api/methods/request_sms_code.rst
+++ b/docs/source/api/methods/request_sms_code.rst
@@ -1,0 +1,21 @@
+################
+request_sms_code
+################
+
+Отправляет SMS-код на номер телефона, указанный при создании экземпляра ``MoyNalog``.
+
+Возвращает: :obj:`SmsChallenge`
+
+- ``challenge_token`` — токен для передачи в ``verify_sms_code()``
+- ``expire_date`` — дата истечения кода
+- ``expire_in`` — время жизни кода в секундах (обычно 120)
+
+
+Использование
+=====
+
+.. code-block:: python
+
+    challenge: SmsChallenge = await nalog.request_sms_code()
+    print(challenge.challenge_token)  # UUID токен
+    print(challenge.expire_in)  # 120

--- a/docs/source/api/methods/verify_sms_code.rst
+++ b/docs/source/api/methods/verify_sms_code.rst
@@ -1,0 +1,24 @@
+################
+verify_sms_code
+################
+
+Верифицирует SMS-код и получает токены авторизации.
+
+Возвращает: :obj:`AuthDetails`
+
+- ``inn`` — ИНН пользователя
+- ``token.value`` — access token
+- ``token.expire_in`` — дата истечения токена
+- ``token.refresh_value`` — refresh token для обновления
+
+
+Использование
+=====
+
+.. code-block:: python
+
+    auth: AuthDetails = await nalog.verify_sms_code(
+        code="123456",
+        challenge_token=challenge.challenge_token,
+    )
+    print(auth.inn)

--- a/examples/add_income.py
+++ b/examples/add_income.py
@@ -2,6 +2,7 @@ import asyncio
 
 from moy_nalog import MoyNalog
 
+# Авторизация по логину и паролю
 nalog = MoyNalog("1234567890", "MyStrongPassword")
 
 
@@ -12,3 +13,20 @@ async def main():
 
 
 asyncio.run(main())
+
+
+# Авторизация по номеру телефона (SMS)
+nalog = MoyNalog(phone="+79991234567")
+
+
+async def main_sms():
+    challenge = await nalog.request_sms_code()
+    code = input("Введите код из SMS: ")
+    await nalog.verify_sms_code(code, challenge.challenge_token)
+
+    await nalog.add_income(
+        "Предоставление информационных услуг #970/2495", amount=1000, quantity=1
+    )
+
+
+asyncio.run(main_sms())

--- a/moy_nalog/types.py
+++ b/moy_nalog/types.py
@@ -19,6 +19,13 @@ class Credentials:
 
 
 @dataclass
+class SmsChallenge:
+    challenge_token: str
+    expire_date: str
+    expire_in: int
+
+
+@dataclass
 class AuthDetails:
     inn: str
     token: Token

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,8 +9,18 @@ def connection():
     return HttpConnection(Credentials("1", "2"))
 
 
+@pytest.fixture
+def sms_connection():
+    return HttpConnection()
+
+
 class TestHttp:
     @pytest.mark.asyncio
     async def test_connection(self, connection: HttpConnection):
         response = await connection.client.get("https://example.com")
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_sms_connection(self, sms_connection: HttpConnection):
+        response = await sms_connection.client.get("https://example.com")
         assert response.status_code == 200

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -11,3 +11,35 @@ async def test_user_method() -> None:
         await nalog.get_user_info()
     except Exception as ex:
         assert isinstance(ex, AuthorizationError)
+
+
+class TestSmsAuthMethods:
+    @pytest.mark.asyncio
+    async def test_request_sms_without_phone_raises(self):
+        nalog = MoyNalog(login="123", password="456")
+        with pytest.raises(AuthorizationError, match="Phone number is required"):
+            await nalog.request_sms_code()
+
+    @pytest.mark.asyncio
+    async def test_verify_sms_without_phone_raises(self):
+        nalog = MoyNalog(login="123", password="456")
+        with pytest.raises(AuthorizationError, match="Phone number is required"):
+            await nalog.verify_sms_code(code="123456", challenge_token="token")
+
+    @pytest.mark.asyncio
+    async def test_api_call_without_sms_verification_raises(self):
+        nalog = MoyNalog(phone="79990001122")
+        with pytest.raises(AuthorizationError, match="verify_sms_code"):
+            await nalog.get_user_info()
+
+    @pytest.mark.asyncio
+    async def test_request_sms_code_invalid_phone(self):
+        nalog = MoyNalog(phone="0000000000")
+        with pytest.raises(AuthorizationError):
+            await nalog.request_sms_code()
+
+    @pytest.mark.asyncio
+    async def test_verify_sms_code_invalid(self):
+        nalog = MoyNalog(phone="0000000000")
+        with pytest.raises(AuthorizationError):
+            await nalog.verify_sms_code(code="000000", challenge_token="invalid")


### PR DESCRIPTION
### Pull Request Title
`add: phone number authorization, update user agents`

### Description

This PR introduces the ability to authorize via **phone number**, providing an alternative to the existing INN (Tax ID) and password method.

**Key Changes:**

*   **Phone Authorization Flow:** Implemented a new multi-step authentication process:
    1.  A method to request a **challenge token** using the phone number.
    2.  Logic to exchange the received **challenge token** and the **SMS verification code** to retrieve the final `Access` and `Refresh` tokens.
*   **User Agents:** Updated the `User-Agent` headers to ensure compatibility and mimic modern clients.
*   **Documentation:** Updated the README/Docs to include examples and usage guides for the new phone authorization method.
*   **Tests:** Added and updated unit tests to cover the new authorization flow and ensure existing functionality remains stable.

---

### Russian translation (for your reference / для справки):
Этот PR добавляет возможность авторизации по **номеру телефона**, предоставляя альтернативу существующему методу через ИНН и пароль.

**Основные изменения:**
*   **Флоу авторизации по телефону:** Реализован новый многоступенчатый процесс аутентификации:
    1.  Метод для запроса **challenge token** (токена вызова) с использованием номера телефона.
    2.  Логика обмена полученного **challenge token** и **SMS-кода** для получения финальных токенов `Access` и `Refresh`.
*   **User Agents:** Обновлены заголовки `User-Agent` для совместимости и имитации современных клиентов.
*   **Документация:** Обновлен README/Docs, добавлены примеры использования нового метода авторизации.
*   **Тесты:** Добавлены и обновлены юнит-тесты для покрытия нового флоу авторизации и проверки стабильности текущего функционала.